### PR TITLE
more changes to make CI amenable for public publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Publish to GitHub Packages
-        run: npm publish --@yuga-labs:registry=https://npm.pkg.github.com/
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: fix formatting of package.json
         run: npx prettier --write package.json
       - name: Commit package.json update

--- a/transfer_portal.sh
+++ b/transfer_portal.sh
@@ -41,10 +41,15 @@ echo "Current directory: $current_dir"
 echo "About to transfer the files from the source to the destination."
 rsync -av --exclude-from="../ape-portal/.gitignore" --exclude=".git" --exclude=".npmrc" --exclude=".husky" "../ape-portal/" .
 
-# Step 7: Update the package.json file to reflect the new package/repo name
+# Step 7: Update the package.json file to reflect several changes for the public repo - name, publishing, etc.
 sed -i '' 's/ape-portal/ape-portal-public/g' package.json
 # update registry from private to public; change https://npm.pkg.github.com to https://registry.npmjs.org
 sed -i '' 's/https:\/\/npm.pkg.github.com/https:\/\/registry.npmjs.org/g' package.json
+# use yq to change the publish step for 'Publish to GitHub Packages' to public access
+yq eval '
+  (.jobs.publish.steps[] | select(.name == "Publish to GitHub Packages") | .run) = "npm publish --access public" |
+  (.jobs.publish.steps[] | select(.name == "Publish to GitHub Packages") | .env) = {"NODE_AUTH_TOKEN": "${{secrets.NPM_TOKEN}}"}
+' -i .github/workflows/publish.yaml
 
 # Step 8: Install the dependencies
 npm install


### PR DESCRIPTION
- use yq for all changes to publish.yaml
- change publish destination and command for `npm publish`, add `env` for the npm token (waiting on devops for the actual token)